### PR TITLE
admin配下のレストラン一覧ページはログインしてないと閲覧できないように修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .env
+.DS_Store

--- a/app/Http/Controllers/Admin/HomeController.php
+++ b/app/Http/Controllers/Admin/HomeController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+class HomeController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+
+    }
+
+    /**
+     * Show the application dashboard.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        return view('admin.home');
+    }
+}

--- a/app/Http/Controllers/Admin/RestaurantsController.php
+++ b/app/Http/Controllers/Admin/RestaurantsController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\DB;
+use App\Restaurant;
 
 class RestaurantsController extends Controller
 {

--- a/app/Http/Controllers/Admin/RestaurantsController.php
+++ b/app/Http/Controllers/Admin/RestaurantsController.php
@@ -16,6 +16,6 @@ class RestaurantsController extends Controller
     public function index()
     {
         $restaurants = Restaurant::all();
-        return view('restaurants.index', ['restaurants' => $restaurants]);
+        return view('admin.restaurants.index', ['restaurants' => $restaurants]);
     }
 }

--- a/app/Http/Controllers/Admin/RestaurantsController.php
+++ b/app/Http/Controllers/Admin/RestaurantsController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\DB;
+
+class RestaurantsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $restaurants = Restaurant::all();
+        return view('restaurants.index', ['restaurants' => $restaurants]);
+    }
+}

--- a/app/Http/Controllers/RestaurantsController.php
+++ b/app/Http/Controllers/RestaurantsController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use App\Restaurant;
 
 class RestaurantsController extends Controller

--- a/resources/views/admin/home.blade.php
+++ b/resources/views/admin/home.blade.php
@@ -1,0 +1,49 @@
+@extends('layouts.app')
+
+@section('content')
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-md-8">
+        <div class="card">
+          <div class="card-header">管理画面ダッシュボード</div>
+
+          @if (Auth::check())
+            <ul>
+              <li>
+                <a href="{{ url('/logout') }}"
+                   onclick="event.preventDefault();
+                                                     document.getElementById('logout-form').submit();">
+                  ログアウトする
+                </a>
+
+                <form id="logout-form" action="{{ url('/logout') }}" method="POST" style="display: none;">
+                  {{ csrf_field() }}
+                </form>
+              </li>
+              <li>
+                <a href="/admin/restaurants">
+                  レストラン管理機能  
+                </a>                
+              </li>
+            </ul>
+          @else
+            <h3>
+              管理機能を利用するにはログインが必要になります。
+            </h3>
+            <p>
+              <a href="/login">ログインする</a>
+            </p>
+          @endif
+          <div class="card-body">
+            @if (session('status'))
+              <div class="alert alert-success">
+                {{ session('status') }}
+              </div>
+            @endif
+            
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection

--- a/resources/views/admin/restaurants/index.blade.php
+++ b/resources/views/admin/restaurants/index.blade.php
@@ -1,0 +1,35 @@
+@extends('layouts.app')
+
+@section('title', 'Page Title')
+
+@section('sidebar')
+  <p>ここはサイドバー領域</p>
+@endsection
+
+@section('content')
+  @if (Auth::check())
+    <div>
+      <h2>
+        店舗一覧
+      </h2>
+      <table class="table">
+        @foreach ($restaurants as $restaurant)
+          <tr>
+            <td>{{ $restaurant->id }}</td>
+            <td>{{ $restaurant->name }}</td>
+            <td>{{ $restaurant->created_at }}</td>
+          </tr>
+        @endforeach
+      </table>
+    </div>
+  @else
+    <h3>
+      ※ログインしてません
+    </h3>
+    <p>
+      <a href="/admin/login">
+      ログインページに移動
+      </a>
+    </p>
+  @endif
+@endsection

--- a/resources/views/admin/restaurants/index.blade.php
+++ b/resources/views/admin/restaurants/index.blade.php
@@ -4,6 +4,17 @@
 
 @section('sidebar')
   <p>ここはサイドバー領域</p>
+  <li>
+    <a href="{{ url('/logout') }}"
+       onclick="event.preventDefault();
+                                                     document.getElementById('logout-form').submit();">
+      Logout
+    </a>
+
+    <form id="logout-form" action="{{ url('/logout') }}" method="POST" style="display: none;">
+      {{ csrf_field() }}
+    </form>
+  </li>
 @endsection
 
 @section('content')

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,69 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">{{ __('Login') }}</div>
+
+                <div class="card-body">
+                    <form method="POST" action="{{ route('login') }}">
+                        @csrf
+
+                        <div class="form-group row">
+                            <label for="email" class="col-sm-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" required autofocus>
+
+                                @if ($errors->has('email'))
+                                    <span class="invalid-feedback">
+                                        <strong>{{ $errors->first('email') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('Password') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password" required>
+
+                                @if ($errors->has('password'))
+                                    <span class="invalid-feedback">
+                                        <strong>{{ $errors->first('password') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <div class="col-md-6 offset-md-4">
+                                <div class="checkbox">
+                                    <label>
+                                        <input type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}> {{ __('Remember Me') }}
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="form-group row mb-0">
+                            <div class="col-md-8 offset-md-4">
+                                <button type="submit" class="btn btn-primary">
+                                    {{ __('Login') }}
+                                </button>
+
+                                <a class="btn btn-link" href="{{ route('password.request') }}">
+                                    {{ __('Forgot Your Password?') }}
+                                </a>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,0 +1,47 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">{{ __('Reset Password') }}</div>
+
+                <div class="card-body">
+                    @if (session('status'))
+                        <div class="alert alert-success">
+                            {{ session('status') }}
+                        </div>
+                    @endif
+
+                    <form method="POST" action="{{ route('password.email') }}">
+                        @csrf
+
+                        <div class="form-group row">
+                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" required>
+
+                                @if ($errors->has('email'))
+                                    <span class="invalid-feedback">
+                                        <strong>{{ $errors->first('email') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group row mb-0">
+                            <div class="col-md-6 offset-md-4">
+                                <button type="submit" class="btn btn-primary">
+                                    {{ __('Send Password Reset Link') }}
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,0 +1,71 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">{{ __('Reset Password') }}</div>
+
+                <div class="card-body">
+                    <form method="POST" action="{{ route('password.request') }}">
+                        @csrf
+
+                        <input type="hidden" name="token" value="{{ $token }}">
+
+                        <div class="form-group row">
+                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ $email ?? old('email') }}" required autofocus>
+
+                                @if ($errors->has('email'))
+                                    <span class="invalid-feedback">
+                                        <strong>{{ $errors->first('email') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('Password') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password" required>
+
+                                @if ($errors->has('password'))
+                                    <span class="invalid-feedback">
+                                        <strong>{{ $errors->first('password') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <label for="password-confirm" class="col-md-4 col-form-label text-md-right">{{ __('Confirm Password') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="password-confirm" type="password" class="form-control{{ $errors->has('password_confirmation') ? ' is-invalid' : '' }}" name="password_confirmation" required>
+
+                                @if ($errors->has('password_confirmation'))
+                                    <span class="invalid-feedback">
+                                        <strong>{{ $errors->first('password_confirmation') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group row mb-0">
+                            <div class="col-md-6 offset-md-4">
+                                <button type="submit" class="btn btn-primary">
+                                    {{ __('Reset Password') }}
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,0 +1,77 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">{{ __('Register') }}</div>
+
+                <div class="card-body">
+                    <form method="POST" action="{{ route('register') }}">
+                        @csrf
+
+                        <div class="form-group row">
+                            <label for="name" class="col-md-4 col-form-label text-md-right">{{ __('Name') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="name" type="text" class="form-control{{ $errors->has('name') ? ' is-invalid' : '' }}" name="name" value="{{ old('name') }}" required autofocus>
+
+                                @if ($errors->has('name'))
+                                    <span class="invalid-feedback">
+                                        <strong>{{ $errors->first('name') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" required>
+
+                                @if ($errors->has('email'))
+                                    <span class="invalid-feedback">
+                                        <strong>{{ $errors->first('email') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('Password') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="password" type="password" class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}" name="password" required>
+
+                                @if ($errors->has('password'))
+                                    <span class="invalid-feedback">
+                                        <strong>{{ $errors->first('password') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <label for="password-confirm" class="col-md-4 col-form-label text-md-right">{{ __('Confirm Password') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
+                            </div>
+                        </div>
+
+                        <div class="form-group row mb-0">
+                            <div class="col-md-6 offset-md-4">
+                                <button type="submit" class="btn btn-primary">
+                                    {{ __('Register') }}
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,4 +14,9 @@
 Route::get('/', function () {
     return view('welcome');
 });
-Route::resource('restaurants', 'RestaurantsController',['only' => ['index','show']]);
+
+
+Route::group(['prefix' => 'admin', 'as' => 'admin.', 'middleware' => 'web', 'namespace' => 'Admin'], function () {
+    Route::resource('restaurants', 'RestaurantsController');
+});
+Route::resource('restaurants', 'RestaurantsController', ['only' => ['index','show']]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,12 +11,11 @@
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
-});
-
-
 Route::group(['prefix' => 'admin', 'as' => 'admin.', 'middleware' => 'web', 'namespace' => 'Admin'], function () {
-    Route::resource('restaurants', 'RestaurantsController');
+    Route::get('/home', 'HomeController@index')->name('home');
+    Route::resource('restaurants', 'RestaurantsController')
+        ->middleware('auth');
 });
 Route::resource('restaurants', 'RestaurantsController', ['only' => ['index','show']]);
+
+Auth::routes();


### PR DESCRIPTION
## このPRについて

issue #2 対応

- IDはEmailだったので、適当なEmailを設定する方針に変更
- パスワードはissue記載通り

## 実装手順

```sh
php artisan make:auth
```

を実行して、認証処理に必要な処理を一式生成されるのでそれを利用

## 振る舞いについて

- ログインしなくても閲覧できるページ
  - /admin/home
  - 本当はここは、/admin/loginとかにして、ログインのフォームが表示されるのが理想だけどひとまずはそこは見合わせてる
- ログイン必須のURL
  - /admin/restaurants

## Authについて

- ログイン処理に必要なController＆Viewを一式作ってくれる
- RailsのDeviseに比べれば、生成される各種処理は少なめなので、Sorceryに近い感じかも