### PR TITLE
レストラン管理画面からCRUD処理行える機能

### DIFF
--- a/app/Http/Controllers/Admin/RestaurantsController.php
+++ b/app/Http/Controllers/Admin/RestaurantsController.php
@@ -79,6 +79,8 @@ class RestaurantsController extends Controller
      */
     public function destroy($id)
     {
-        //
+        $restaurant = Restaurant::find($id);
+        $restaurant->delete();
+        return redirect('/admin/restaurants');
     }
 }

--- a/app/Http/Controllers/Admin/RestaurantsController.php
+++ b/app/Http/Controllers/Admin/RestaurantsController.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace App\Http\Controllers\Admin;
 
 use Illuminate\Http\Request;
@@ -17,5 +16,65 @@ class RestaurantsController extends Controller
     {
         $restaurants = Restaurant::all();
         return view('admin.restaurants.index', ['restaurants' => $restaurants]);
+    }
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        return view('admin.restaurants.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        eval(\Psy\sh());
+        $restaurant = new Restaurant;
+        $restaurant->name = $request->name;
+        $restaurant->address = $request->address;
+        $restaurant->save();
+        $restaurants = Restaurant::all();
+        return view('admin.restaurants.index', ['restaurants' => $restaurants]);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+
+    public function edit($id)
+    {
+        //
+    }
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
     }
 }

--- a/app/Http/Controllers/Admin/RestaurantsController.php
+++ b/app/Http/Controllers/Admin/RestaurantsController.php
@@ -24,7 +24,8 @@ class RestaurantsController extends Controller
      */
     public function create()
     {
-        return view('admin.restaurants.create');
+        $restaurant = new Restaurant;
+        return view('admin.restaurants.create', ['restaurant' => $restaurant]);
     }
 
     /**
@@ -35,13 +36,11 @@ class RestaurantsController extends Controller
      */
     public function store(Request $request)
     {
-        eval(\Psy\sh());
         $restaurant = new Restaurant;
         $restaurant->name = $request->name;
         $restaurant->address = $request->address;
         $restaurant->save();
-        $restaurants = Restaurant::all();
-        return view('admin.restaurants.index', ['restaurants' => $restaurants]);
+        return redirect('/admin/restaurants');
     }
 
     /**
@@ -53,7 +52,8 @@ class RestaurantsController extends Controller
 
     public function edit($id)
     {
-        //
+        $restaurant = Restaurant::find($id);
+        return view('admin.restaurants.edit', ['restaurant' => $restaurant]);
     }
     /**
      * Update the specified resource in storage.
@@ -64,7 +64,11 @@ class RestaurantsController extends Controller
      */
     public function update(Request $request, $id)
     {
-        //
+        $restaurant = Restaurant::find($id);
+        $restaurant->name = $request->name;
+        $restaurant->address = $request->address;
+        $restaurant->save();
+        return redirect('/admin/restaurants');
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "fzaninotto/faker": "^1.4",
         "mockery/mockery": "^1.0",
         "nunomaduro/collision": "^2.0",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.0",
+        "psy/psysh": "0.8.18"
     },
     "autoload": {
         "classmap": [

--- a/resources/views/admin/components/form.blade.php
+++ b/resources/views/admin/components/form.blade.php
@@ -1,0 +1,9 @@
+<div class="form-group">
+  <label for="name">店舗名</label>
+  <input id="name" type="text" class="form-control" name="name" value="{{$restaurant->name}}" required autofocus>
+</div>
+<div class="form-group">
+  <label for="address">所在地</label>
+  <input id="address" type="text" class="form-control" name="address" value="{{$restaurant->address}}" required>
+</div>
+<button type="submit" name="submit" class="btn btn-primary">{{ $submit }}</button>

--- a/resources/views/admin/restaurants/create.blade.php
+++ b/resources/views/admin/restaurants/create.blade.php
@@ -1,0 +1,16 @@
+<div class="container">
+  <h1>店舗作成</h1>
+  <form action="{{ url('/admin/restaurants') }}" method="post">
+    @csrf
+    @method('POST')
+    <div class="form-group">
+      <label for="name">店舗名</label>
+      <input id="name" type="text" class="form-control" name="name" required autofocus>
+    </div>
+    <div class="form-group">
+      <label for="address">所在地</label>
+      <input id="address" type="text" class="form-control" name="address" required>
+    </div>
+    <button type="submit" name="submit" class="btn btn-primary">登録する</button>
+  </form>
+</div>

--- a/resources/views/admin/restaurants/edit.blade.php
+++ b/resources/views/admin/restaurants/edit.blade.php
@@ -1,11 +1,11 @@
 <div class="container">
-  <h1>店舗作成</h1>
-  <form action="{{ url('/admin/restaurants') }}" method="post">
+  <h1>店舗編集</h1>
+  <form action="{{ url('/admin/restaurants/'.$restaurant->id) }}" method="POST">
     @csrf
-    @method('POST')
+    @method('PUT')
     @component('admin.components.form', ['restaurant' => $restaurant])
     @slot('submit')
-    登録する
+    更新する
     @endslot
     @endcomponent
   </form>

--- a/resources/views/admin/restaurants/index.blade.php
+++ b/resources/views/admin/restaurants/index.blade.php
@@ -24,11 +24,26 @@
         店舗一覧
       </h2>
       <table class="table">
+        <thead>
+          <tr>
+            <th>id</th>
+            <th>店舗名</th>
+            <th>住所</th>
+            <th>作成日</th>
+            <th>編集</th>
+          </tr>
+        </thead>
         @foreach ($restaurants as $restaurant)
           <tr>
             <td>{{ $restaurant->id }}</td>
             <td>{{ $restaurant->name }}</td>
+            <td>{{ $restaurant->address }}</td>
             <td>{{ $restaurant->created_at }}</td>
+            <td>
+              <a href="/admin/restaurants/{{ $restaurant->id }}/edit">
+                <button class="btn btn-info">編集する</button>
+              </a>
+            </td>
           </tr>
         @endforeach
       </table>

--- a/resources/views/admin/restaurants/index.blade.php
+++ b/resources/views/admin/restaurants/index.blade.php
@@ -20,6 +20,11 @@
 @section('content')
   @if (Auth::check())
     <div>
+      <a href="/admin/restaurants/create">
+        <button class="btn btn-primary">新規作成</button>
+      </a>
+    </div>
+    <div>
       <h2>
         店舗一覧
       </h2>

--- a/resources/views/admin/restaurants/index.blade.php
+++ b/resources/views/admin/restaurants/index.blade.php
@@ -31,6 +31,7 @@
             <th>住所</th>
             <th>作成日</th>
             <th>編集</th>
+            <th>削除</th>
           </tr>
         </thead>
         @foreach ($restaurants as $restaurant)
@@ -43,6 +44,13 @@
               <a href="/admin/restaurants/{{ $restaurant->id }}/edit">
                 <button class="btn btn-info">編集する</button>
               </a>
+            </td>
+            <td>
+              <form action="/admin/restaurants/{{ $restaurant->id }}" method="POST">
+                {{ csrf_field() }}
+                @method('DELETE')
+                <button class="btn btn-danger">削除</button>
+              </form>
             </td>
           </tr>
         @endforeach

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>飲食店予約システム - @yield('title')</title>
+    <link rel="stylesheet" href="{{ mix('css/app.css') }}">
   </head>
   <body>
     @section('sidebar')


### PR DESCRIPTION
## このPRについて

issue #4 対応

## 実装内容

- [x] レストラン一覧画面から任意の店舗の削除が行える
- [x] レストラン一覧画面からレストランの新規作成の画面に遷移してそこで店舗が登録できる
- [x] レストラン一覧画面からレストランの編集画面に遷移して情報の編集が行える

## 画面

削除時の確認処理等細かい制御は入れてないがひとまず、以下のような画面で一通りのことが行えるように実装

![screenshot 2018-04-13 19 13 23](https://user-images.githubusercontent.com/950924/38729821-3484d8dc-3f4f-11e8-8e6f-49d9c5521ae9.jpg)

![screenshot 2018-04-13 19 16 49](https://user-images.githubusercontent.com/950924/38729837-436eb8c2-3f4f-11e8-8ce3-a487e0b5c845.jpg)
